### PR TITLE
Add configuration driver + extend EditorComponent

### DIFF
--- a/src/DropBlockEditorConfigurationDriver.php
+++ b/src/DropBlockEditorConfigurationDriver.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Jeffreyvr\DropBlockEditorMailcoach;
+
+use Jeffreyvr\DropBlockEditorMailcoach\Http\Livewire\EditorPlaceholder;
+use Spatie\Mailcoach\Domain\Settings\Support\EditorConfiguration\Editors\EditorConfigurationDriver;
+
+class DropBlockEditorConfigurationDriver extends EditorConfigurationDriver
+{
+    public static function label(): string
+    {
+        return 'DropBlock';
+    }
+
+    public function getClass(): string
+    {
+        return EditorPlaceholder::class;
+    }
+}

--- a/src/Http/Livewire/EditorPlaceholder.php
+++ b/src/Http/Livewire/EditorPlaceholder.php
@@ -4,9 +4,10 @@ namespace Jeffreyvr\DropBlockEditorMailcoach\Http\Livewire;
 
 use Livewire\Component;
 use Spatie\Mailcoach\Domain\Campaign\Models\Concerns\HasHtmlContent;
+use Spatie\Mailcoach\Http\App\Livewire\EditorComponent;
 use Spatie\Mailcoach\Http\App\Livewire\LivewireFlash;
 
-class EditorPlaceholder extends Component
+class EditorPlaceholder extends EditorComponent
 {
     use LivewireFlash;
 

--- a/src/Http/Livewire/EditorPlaceholder.php
+++ b/src/Http/Livewire/EditorPlaceholder.php
@@ -2,7 +2,6 @@
 
 namespace Jeffreyvr\DropBlockEditorMailcoach\Http\Livewire;
 
-use Livewire\Component;
 use Spatie\Mailcoach\Domain\Campaign\Models\Concerns\HasHtmlContent;
 use Spatie\Mailcoach\Http\App\Livewire\EditorComponent;
 use Spatie\Mailcoach\Http\App\Livewire\LivewireFlash;


### PR DESCRIPTION
- The configuration driver makes it selectable from the editor settings after adding it to the `mailcoach.editors` config key
- The Placeholder needs to extend `EditorComponent` for it to work

This at least makes it render and show inside Mailcoach, couldn't get the save button to work yet